### PR TITLE
fix image overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -112,6 +112,7 @@ li a:hover {
     margin-bottom: 10px;
 }
 #perImg{
+    overflow: hidden;
     border-radius: 50%;
     max-height: 50%;
 }


### PR DESCRIPTION
Played around with various solutions, this seems to be the best one too keep the images within the container when the browser is resized to half the screen.